### PR TITLE
Support building just the libraries.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,10 @@
 # ----------------
 #
 # Setup:                   make [VAR=VALUE] setup (see below)
-# Build libgpr2:           make
-# Install libgpr2:         make install
+# Build libgpr2 & tools:   make
+# Build libgpr2:           make build-libs
+# Install libgpr2 & tools: make install
+# Install libgpr2:         make install-libs
 
 # Variables which can be set:
 #
@@ -151,7 +153,7 @@ DOCOUT=${BUILD_ROOT}/attributes.json
 # build #
 #########
 
-all: ${LIBGPR2_TYPES:%=build-lib-%} build-tools
+all: build-libs build-tools
 
 # Knowledge base
 ${KB_BUILD_DIR}:
@@ -162,6 +164,8 @@ ${KB_BUILD_DIR}/config.kb: ${KB_BUILD_DIR} $(wildcard $(GPR2KBDIR)/*)
 	${KB_BUILD_DIR}/collect_kb -o $@ ${GPR2KBDIR}
 
 # Libgpr2
+build-libs: ${LIBGPR2_TYPES:%=build-lib-%}
+
 build-lib-%: ${KB_BUILD_DIR}/config.kb
 ifneq (${GPR2_BUILD},gnatcov)
 	${BUILDER} -XLIBRARY_TYPE=$* -XXMLADA_BUILD=$* \


### PR DESCRIPTION
The current Makefile doesn't support building the libraries and not the tools, whereas the install targets provide for installing just the libraries.

The initial commentary is misleading (it doesn't mention the tools).

This change adds a target 'build-libs', to build just the libraries.

  * Makefile (initial commentary): Document the actual effects of the current targets, and add targets for just the libs. (all): use build-libs. (build-libs): New target, follows design of the install-libs target.